### PR TITLE
Fix MmsSmsDatabaseHelper onUpgrade always destroying the database

### DIFF
--- a/src/com/android/providers/telephony/MmsSmsDatabaseHelper.java
+++ b/src/com/android/providers/telephony/MmsSmsDatabaseHelper.java
@@ -1658,6 +1658,12 @@ public class MmsSmsDatabaseHelper extends SQLiteOpenHelper {
                 db.endTransaction();
             }
             // fall through
+        case 67:
+            if (currentVersion <= 67) {
+                return;
+            }
+            // 67 was adding RcsProvider, but that was removed.
+            return;
         }
 
         Log.e(TAG, "Destroying all old data.");


### PR DESCRIPTION
Commit f589e3973167cf238f0997fc63ecc1e684d10527 mistakenly removed
the whole 67 version check step instead of just the upgrade steps,
so the upgrade ended up always falling through, wiping and recreating
the database.

Test: Build, observe database not being wiped on upgrade

Change-Id: I4d1d5c71a90e18b7d01de8ded1342c458d5f1bde