### PR TITLE
add infrastructure for extended SIM state

### DIFF
--- a/src/com/android/providers/telephony/TelephonyProvider.java
+++ b/src/com/android/providers/telephony/TelephonyProvider.java
@@ -568,6 +568,7 @@ public class TelephonyProvider extends ContentProvider
     @VisibleForTesting
     public static String getStringForSimInfoTableCreation(String tableName) {
         return "CREATE TABLE " + tableName + "("
+                + Telephony.SimInfo.COLUMN_EXT_SIM_STATE + " TEXT,"
                 + Telephony.SimInfo.COLUMN_UNIQUE_KEY_SUBSCRIPTION_ID
                 + " INTEGER PRIMARY KEY AUTOINCREMENT,"
                 + Telephony.SimInfo.COLUMN_ICC_ID + " TEXT NOT NULL,"
@@ -764,6 +765,32 @@ public class TelephonyProvider extends ContentProvider
             XmlUtils.beginDocument(parser, "apns");
             int publicversion = Integer.parseInt(parser.getAttributeValue(null, "version"));
             int version = DATABASE_VERSION | publicversion;
+
+            if (DATABASE_VERSION == 74 << 16) {
+                // All of this is not needed when DATABASE_VERSION gets incremented to 75 << 16 
+                // in AOSP.
+
+                final int extDatabaseVersion = 1;
+                // We want a database version that won't conflict with AOSP versions. Insert our
+                // extDatabaseVersion between the bits of the major database version and the
+                // public version. That way, if AOSP increments DATABASE_VERSION or AOSP / vendor 
+                // increments publicversion, it would still be recognized as a new upgrade.
+
+                // DATABASE version is shifted 16 bits
+                // We can just use around 8 bits for extDatabaseVersion, and then put publicVersion
+                // in the remaining bits. publicVersion is originally in the least significant bits
+                version = DATABASE_VERSION | (extDatabaseVersion << 8) | publicversion;
+
+                if (version <= (74 << 16 | 6)) {
+                    throw new AssertionError(
+                        "ext version should be an increment over the latest upstream migration");
+                }
+                if (version >= 75 << 16) {
+                    throw new AssertionError("ext version too large and would conflict with" +
+                            "future AOSP's DATABASE_VERSION");
+                }
+            }
+
             if (VDBG) log("getVersion:- version=0x" + Integer.toHexString(version));
             return version;
         } catch (Exception e) {
@@ -2227,6 +2254,23 @@ public class TelephonyProvider extends ContentProvider
                 }
                 oldVersion = 74 << 16 | 6;
             }
+            // GrapheneOS: DATABASE_VERSION is 74, EXT version is 1, apn publicversion is >= 6
+            if (oldVersion < ((74 << 16) | (1 << 8) | 6)) {
+                try {
+                    // Try to update the siminfo table. It might not be there.
+                    db.execSQL("ALTER TABLE " + SIMINFO_TABLE + " ADD COLUMN "
+                            + Telephony.SimInfo.COLUMN_EXT_SIM_STATE
+                            + " TEXT DEFAULT '';");
+                } catch (SQLiteException e) {
+                    if (DBG) {
+                        log("onUpgrade failed to update " + SIMINFO_TABLE
+                                + " to add extened SIM state");
+                    }
+                }
+                oldVersion = (74 << 16) | (1 << 8) | 6;
+            }
+            // Add new AOSP upstream migrations below
+
             if (DBG) {
                 log("dbh.onUpgrade:- db=" + db + " oldV=" + oldVersion + " newV=" + newVersion);
             }
@@ -4174,7 +4218,6 @@ public class TelephonyProvider extends ContentProvider
                         backedUpSimInfoEntry.getString(
                                 Telephony.SimInfo.COLUMN_SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY,
                                 DEFAULT_STRING_COLUMN_VALUE));
-
             }
             if (backupDataFormatVersion >= 73 << 16) {
                 contentValues.put(

--- a/src/com/android/providers/telephony/TelephonyProvider.java
+++ b/src/com/android/providers/telephony/TelephonyProvider.java
@@ -437,6 +437,9 @@ public class TelephonyProvider extends ContentProvider
         // SIM_INFO_COLUMNS_TO_BACKUP. For both cases, add appropriate versioning logic in
         // convertBackedUpDataToContentValues(ContentValues contenValues)
         SIM_INFO_COLUMNS_TO_BACKUP.put(
+                Telephony.SimInfo.COLUMN_EXT_SIM_STATE,
+                Cursor.FIELD_TYPE_STRING);
+        SIM_INFO_COLUMNS_TO_BACKUP.put(
                 Telephony.SimInfo.COLUMN_UNIQUE_KEY_SUBSCRIPTION_ID, Cursor.FIELD_TYPE_INTEGER);
         SIM_INFO_COLUMNS_TO_BACKUP.put(
                 Telephony.SimInfo.COLUMN_ICC_ID, Cursor.FIELD_TYPE_STRING);
@@ -4217,6 +4220,10 @@ public class TelephonyProvider extends ContentProvider
                         Telephony.SimInfo.COLUMN_SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY,
                         backedUpSimInfoEntry.getString(
                                 Telephony.SimInfo.COLUMN_SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY,
+                                DEFAULT_STRING_COLUMN_VALUE));
+                contentValues.put(
+                        Telephony.SimInfo.COLUMN_EXT_SIM_STATE,
+                        backedUpSimInfoEntry.getString(Telephony.SimInfo.COLUMN_EXT_SIM_STATE,
                                 DEFAULT_STRING_COLUMN_VALUE));
             }
             if (backupDataFormatVersion >= 73 << 16) {

--- a/tests/src/com/android/providers/telephony/TelephonyDatabaseHelperTest.java
+++ b/tests/src/com/android/providers/telephony/TelephonyDatabaseHelperTest.java
@@ -916,6 +916,22 @@ public final class TelephonyDatabaseHelperTest extends TelephonyTestBase {
                 Telephony.SimInfo.COLUMN_SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY));
     }
 
+    @Test
+    public void databaseHelperOnUpgrade_hasExtendedSimState() {
+        Log.d(TAG, "databaseHelperOnUpgrade_hasExtendedSimState");
+        // (5 << 16 | 6) is the first upgrade trigger in onUpgrade
+        SQLiteDatabase db = mInMemoryDbHelper.getWritableDatabase();
+        mHelper.onUpgrade(db, (4 << 16), TelephonyProvider.getVersion(mContext));
+
+        // the upgraded db must have Telephony.SimInfo.COLUMN_SATELLITE_ENTITLEMENT_PLMNS
+        Cursor cursor = db.query("siminfo", null, null, null, null, null, null);
+        String[] upgradedColumns = cursor.getColumnNames();
+        Log.d(TAG, "siminfo columns: " + Arrays.toString(upgradedColumns));
+
+        assertTrue(Arrays.asList(upgradedColumns).contains(
+                Telephony.SimInfo.COLUMN_EXT_SIM_STATE));
+    }
+
     /**
      * Helper for an in memory DB used to test the TelephonyProvider#DatabaseHelper.
      *

--- a/tests/src/com/android/providers/telephony/TelephonyProviderTest.java
+++ b/tests/src/com/android/providers/telephony/TelephonyProviderTest.java
@@ -999,6 +999,9 @@ public class TelephonyProviderTest {
         assertEquals(ARBITRARY_SIMINFO_DB_TEST_STRING_VALUE_1,
                 getStringValueFromCursor(cursor,
                         SimInfo.COLUMN_SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY));
+        assertEquals(ARBITRARY_SIMINFO_DB_TEST_STRING_VALUE_1,
+                getStringValueFromCursor(cursor,
+                        SimInfo.COLUMN_EXT_SIM_STATE));
 
         assertRestoredSubIdIsRemembered();
     }

--- a/tests/src/com/android/providers/telephony/TelephonyProviderTest.java
+++ b/tests/src/com/android/providers/telephony/TelephonyProviderTest.java
@@ -275,6 +275,7 @@ public class TelephonyProviderTest {
                 arbitraryStringVal);
         contentValues.put(SimInfo.COLUMN_SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY,
                 arbitraryStringVal);
+        contentValues.put(SimInfo.COLUMN_EXT_SIM_STATE, arbitraryStringVal);
         return contentValues;
     }
 
@@ -781,6 +782,9 @@ public class TelephonyProviderTest {
         final String insertSatelliteEntitlementServiceTypeMap = "exampleServiceTypeMap";
         final String insertSatelliteEntitlementDataServicePolicy = "exampleDataServicePolicy";
         final String insertSatelliteEntitlementVoiceServicePolicy = "exampleVoiceServicePolicy";
+        final String insertExtSimState = "CkESHQoZaGlkZV9lbmhhbmNlZF80Z19sdGVfYm9vbCgAEiAKHGNhcnJp"
+                + "ZXJfdm9sdGVfYXZhaWxh\n"
+                + "YmxlX2Jvb2woAQ==";
         contentValues.put(SubscriptionManager.UNIQUE_KEY_SUBSCRIPTION_ID, insertSubId);
         contentValues.put(SubscriptionManager.DISPLAY_NAME, insertDisplayName);
         contentValues.put(SubscriptionManager.CARRIER_NAME, insertCarrierName);
@@ -812,6 +816,7 @@ public class TelephonyProviderTest {
                 insertSatelliteEntitlementDataServicePolicy);
         contentValues.put(SubscriptionManager.SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY,
                 insertSatelliteEntitlementVoiceServicePolicy);
+        contentValues.put(SubscriptionManager.EXT_SIM_STATE, insertExtSimState);
 
         Log.d(TAG, "testSimTable Inserting contentValues: " + contentValues);
         mContentResolver.insert(SimInfo.CONTENT_URI, contentValues);
@@ -838,7 +843,8 @@ public class TelephonyProviderTest {
             SubscriptionManager.SATELLITE_ENTITLEMENT_DATA_PLAN_PLMNS,
             SubscriptionManager.SATELLITE_ENTITLEMENT_SERVICE_TYPE_MAP,
             SubscriptionManager.SATELLITE_ENTITLEMENT_DATA_SERVICE_POLICY,
-            SubscriptionManager.SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY
+            SubscriptionManager.SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY,
+            SubscriptionManager.EXT_SIM_STATE
         };
         final String selection = SubscriptionManager.DISPLAY_NAME + "=?";
         String[] selectionArgs = { insertDisplayName };
@@ -871,6 +877,7 @@ public class TelephonyProviderTest {
         final String resultSatelliteEntitlementServiceTypeMap = cursor.getString(17);
         final String resultSatelliteEntitlementDataServicePolicy = cursor.getString(18);
         final String resultSatelliteEntitlementVoiceServicePolicy = cursor.getString(19);
+        final String resultExtendedSimState = cursor.getString(20);
         assertEquals(insertSubId, resultSubId);
         assertEquals(insertCarrierName, resultCarrierName);
         assertEquals(insertCardId, resultCardId);
@@ -895,6 +902,7 @@ public class TelephonyProviderTest {
                 resultSatelliteEntitlementDataServicePolicy);
         assertEquals(insertSatelliteEntitlementVoiceServicePolicy,
                 resultSatelliteEntitlementVoiceServicePolicy);
+        assertEquals(insertExtSimState, resultExtendedSimState);
 
 
         // delete test content
@@ -991,6 +999,7 @@ public class TelephonyProviderTest {
         assertEquals(ARBITRARY_SIMINFO_DB_TEST_STRING_VALUE_1,
                 getStringValueFromCursor(cursor,
                         SimInfo.COLUMN_SATELLITE_ENTITLEMENT_VOICE_SERVICE_POLICY));
+
         assertRestoredSubIdIsRemembered();
     }
 


### PR DESCRIPTION
Part of changeset with changes to
- frameworks/base: https://github.com/GrapheneOS/platform_frameworks_base/pull/256
- frameworks/opt/telephony: https://github.com/GrapheneOS/platform_frameworks_opt_telephony/pull/11
- packages/providers/TelephonyProvider
- packages/apps/CarrierConfig2: https://github.com/GrapheneOS/platform_packages_apps_CarrierConfig2/pull/4

Test: `atest TelephonyDatabaseHelperTest TelephonyProviderTest` (not the CTS one)

```
Summary (Test executed with 1 devices.)
-------
arm64-v8a TelephonyProviderTests: Passed: 78, Failed: 0, Ignored: 0, Assumption Failed: 0  

All tests passed!
```