### PR TITLE
gmscompat: allow GmsCore to read OTP SMS of its clients

### DIFF
--- a/src/com/android/providers/telephony/SmsProvider.java
+++ b/src/com/android/providers/telephony/SmsProvider.java
@@ -462,9 +462,17 @@ public class SmsProvider extends ContentProvider {
                         Sms.CONTAINS_OTP, Sms.OTP_TYPE_PENDING, Sms.DATE, pendingOtpCutoff));
                 final String hash = PackageBasedTokenUtil.generatePackageBasedToken(
                         getContext().getPackageManager(), callingPackage);
+                var packageHashes = new ArrayList<String>();
                 if (hash != null) {
+                    packageHashes.add(hash);
+                }
+
+                SmsProviderExt.maybeGetGmsCoreDependantPackageHashes(requireContext(),
+                        callingPackage, callerUserHandle, packageHashes);
+
+                for (String packageHash : packageHashes) {
                     where.append(String.format(" OR (%s LIKE '%%%s%%')",
-                            Sms.BODY, hash));
+                            Sms.BODY, packageHash));
                 }
                 qb.appendWhereStandalone(where.toString());
             }

--- a/src/com/android/providers/telephony/SmsProviderExt.java
+++ b/src/com/android/providers/telephony/SmsProviderExt.java
@@ -1,0 +1,42 @@
+package com.android.providers.telephony;
+
+import android.content.Context;
+import android.content.pm.ApplicationInfo;
+import android.content.pm.PackageManager;
+import android.ext.AppInfoExtFlag;
+import android.ext.PackageId;
+import android.os.UserHandle;
+
+import com.android.internal.telephony.PackageBasedTokenUtil;
+
+import java.util.ArrayList;
+
+class SmsProviderExt {
+
+    static void maybeGetGmsCoreDependantPackageHashes(Context ctx, String callingPackage,
+                                                      UserHandle callerUser, ArrayList<String> dst) {
+        if (!PackageId.GMS_CORE_NAME.equals(callingPackage)) {
+            return;
+        }
+
+        ApplicationInfo callerAppInfo;
+        PackageManager pm = ctx.getPackageManager();
+        int callerUserId = callerUser.getIdentifier();
+        try {
+            callerAppInfo = pm.getApplicationInfoAsUser(PackageId.GMS_CORE_NAME, 0, callerUserId);
+        } catch (PackageManager.NameNotFoundException e) {
+            return;
+        }
+        if (callerAppInfo.ext().getPackageId() != PackageId.GMS_CORE) {
+            return;
+        }
+
+        for (ApplicationInfo app : pm.getInstalledApplicationsAsUser(0, callerUserId)) {
+            if (app.ext().hasFlag(AppInfoExtFlag.HAS_GMSCORE_CLIENT_LIBRARY)) {
+                // GmsCompat: allow GmsCore to read SMS OTP that are addressed to
+                // its clients if GmsCore has the SMS permission
+                dst.add(PackageBasedTokenUtil.generatePackageBasedToken(pm, app.packageName));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Since 16 QPR2, unprivileged apps that have the SMS permission aren't allowed to read OTP SMS that aren't addressed to them.

This commit allows GmsCore to read OTP SMS that are addressed to its clients. GmsCore is trusted by its clients and they run the GmsCore client library inside their own processes.